### PR TITLE
Updated PromptReco.py to make nthreads optional

### DIFF
--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -43,9 +43,6 @@ class RunPromptReco:
         if self.inputLFN == None:
             msg = "No --lfn specified"
             raise RuntimeError(msg)
-        if self.nThreads == None:
-            msg = "No --nThreads specified"
-            raise RuntimeError(msg)
 
         try:
             scenario = getScenario(self.scenario)


### PR DESCRIPTION
I deleted the lines that checked for a runtime error if nthreads was None.

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
